### PR TITLE
Misc. user-facing improvements to packaging, CLI and Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ The **environment** needed to install and run VISION v2 toolkit requires the fol
    1. Python version 3.10 or later;
    2. cf-python at a version of minimum of 3.17.0,
      see https://ncas-cms.github.io/cf-python/installation.html for guidance;
-   3. esmpy at version of minimum 8.7.0, see the 'Optional -> Regridding' sub-section in the installation
+   3. ESMPy at version of minimum 8.7.0, see the 'Optional -> Regridding' sub-section in the installation
    guidance for cf-python linked above for means to install this (conda/mamba makes it simplest);
+
+and if you want to do any plotting with the toolkit you will also need:
+
    4. cf-plot at a version of minimum 3.4.0, see https://ncas-cms.github.io/cf-plot/installation.html
    for guidance.
 
@@ -39,7 +42,7 @@ Note: soon the library will be added to PyPI and will be installable with `pip`.
 follow these steps.
 
 1.  Clone this repository. Use
-    `git clone <HTTPS path to this repo>` as below, or you can clone via SS or the GitHub CLI
+    `git clone <HTTPS path to this repo>` as below, or you can clone via SSH or the GitHub CLI
     (for help if required see
     https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository):
 

--- a/README.md
+++ b/README.md
@@ -19,19 +19,46 @@ from a recent talk given by a VISION team member.
 
 ### Installing the toolkit
 
-1. **Install** the toolkit by cloning this repository and running `pip install -e .` in the root
-   directory of it. Note you do not need to do this to run the script, since you can
-   run it with `python visiontoolkit/visiontoolkit.py`, but with that installation
-   you can run and use the command `visiontoolkit` instead of having to call the script
-   with the Python interpreter.
+#### Environment
 
-4. The **environment** you need will to run it requires the following:
+The **environment** needed to install and run VISION v2 toolkit requires the following:
 
    1. Python version 3.10 or later;
    2. cf-python at a version of minimum of 3.17.0,
      see https://ncas-cms.github.io/cf-python/installation.html for guidance;
-   3. cf-plot  at a version of minimum 3.4.0, see https://ncas-cms.github.io/cf-plot/installation.html
+   3. esmpy at version of minimum 8.7.0, see the 'Optional -> Regridding' sub-section in the installation
+   guidance for cf-python linked above for means to install this (conda/mamba makes it simplest);
+   4. cf-plot at a version of minimum 3.4.0, see https://ncas-cms.github.io/cf-plot/installation.html
    for guidance.
+
+#### Commands to install
+
+**Install** the toolkit by following these steps:
+
+Note: soon the library will be added to PyPI and will be installable with `pip`. Until then,
+follow these steps.
+
+1.  Clone this repository. Use
+    `git clone <HTTPS path to this repo>` as below, or you can clone via SS or the GitHub CLI
+    (for help if required see
+    https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository):
+
+    ```console
+    $ git clone https://github.com/NCAS-VISION/VISION-toolkit-v2-development.git
+    ```
+
+2. Install locally by changing into the root directory of the repo and running an 'editable' `pip` command:
+
+    ``` console
+    $ cd VISION-toolkit-v2-development
+    $ pip install -e .
+    ```
+
+:warning: Warning: if you don't use the `pip` install command above and instead try to run the toolkit with
+the Python interpreter like a Python script using `python visiontoolkit/visiontoolkit.py` or similar,
+there will be errors due to relative imports using `.<module>` syntax. With the `pip` command above
+applied successfully, you will be able to call `visiontoolkit` as a command and therefore run VISION v2
+as a proper CLI (or alternatively use the VISION v2 Python API).
 
 
 ### Running the toolkit

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -45,6 +45,7 @@ Co-location and bounding
 .. autosummary::
    :toctree: generated
 
+   colocate
    colocate_single_file
    bounding_box_query
    subspace_to_spatiotemporal_bounding_box

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -1,4 +1,4 @@
-
+.. _PythonAPI:
 
 Application Programming Interface (API) Reference
 =================================================

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,6 +1,57 @@
-
+.. _Installation:
 
 Installation
 ============
 
-TODO
+Dependencies
+------------
+
+The **environment** needed to install and run VISION v2 toolkit requires the following:
+
+   1. Python version 3.10 or later;
+   2. cf-python at a version of minimum of 3.17.0,
+     see https://ncas-cms.github.io/cf-python/installation.html for guidance;
+   3. ESMPy at version of minimum 8.7.0, see the 'Optional -> Regridding' sub-section in the installation
+   guidance for cf-python linked above for means to install this (conda/mamba makes it simplest);
+
+and if you want to do any plotting with the toolkit you will also need:
+
+   4. cf-plot at a version of minimum 3.4.0, see https://ncas-cms.github.io/cf-plot/installation.html
+   for guidance.
+
+
+Commands to install
+-------------------
+
+**Install** the toolkit by following these steps:
+
+Note: soon the library will be added to PyPI and will be installable with `pip`. Until then,
+follow these steps.
+
+1.  Clone the code repository. Use
+    `git clone <toolkit path>` as below, or you can clone via SSH or the GitHub CLI
+    (for help if required see
+    https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository):
+
+    .. code-block:: console
+
+       $ git clone https://github.com/NCAS-VISION/VISION-toolkit-v2-development.git
+    
+
+2. Install locally by changing into the root directory of the repo and running an 'editable' `pip` command:
+
+    .. code-block:: console
+
+       $ cd VISION-toolkit-v2-development
+       $ pip install -e .
+
+
+:warning: Warning: if you don't use the `pip` install command above and instead try to run the toolkit with
+the Python interpreter like a Python script using `python visiontoolkit/visiontoolkit.py` or similar,
+there will be errors due to relative imports using `.<module>` syntax. With the `pip` command above
+applied successfully, you will be able to call `visiontoolkit` as a command and therefore run VISION v2
+as a proper CLI (or alternatively use the VISION v2 Python API).
+
+
+
+

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -12,9 +12,9 @@ Introduction
 
 .. warning::
 
-   This documentation is under construction until the
-   end of March 2025, so significant parts may be missing
-   until that time.
+   This documentation is under development so may change
+   signfiicantly, but everything contained within should
+   remain accurate (and code snippets should run).
 
 
 What is the VISION Toolkit?

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,6 +1,67 @@
-
+.. _Quickstart:
 
 Quickstart
 ==========
 
-TODO
+Running the toolkit
+-------------------
+
+Via the command line: the `visiontoolkit` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Install the toolkit as covered in the :ref:`installation guide <Installation>`.
+You will then have access to the `visiontoolkit` command which is the means to
+run and configure the toolkit. To understand the available options
+for configuration, run with the `--help` option for a summary of the
+available command-line interface:
+
+.. code-block:: console
+
+   $ visiontoolkit --help
+
+Note that configuration can be made either by:
+
+* specifying valid keywords the command line, or
+* through use of a configuration file in YAML format specified using the
+  `--config-file` (equivalently `-c`) option followed by a valid path to
+  the configuration file provided on the command line.
+
+
+Examples
+%%%%%%%%
+  
+For example, this repository contains example configuration files for running
+with both UM and WRF model inputs, though note both assume pre-processing
+has been done on the input data to ensure correct form and CF Compliance
+(more information will be added about this here soon):
+
+.. code-block:: console
+
+   $ cd visiontoolkit
+   $ visiontoolkit --config-file="configurations/um-faam-stanco-1.json"
+
+or using WRF model input:
+
+.. code-block:: console
+
+   $ cd visiontoolkit
+   $ visiontoolkit --config-file="configurations/wrf-faam-stanco-1.json"
+
+The above examples are of flight trajectories. A satellite observation case example is:
+
+.. code-block:: console
+
+   $ cd visiontoolkit
+   $ visiontoolkit --config-file="configurations/um-satellite-1.json"
+
+
+Via the Python API
+^^^^^^^^^^^^^^^^^^
+
+You can also use the toolkit through the Python API which is documented
+:ref:`here <PythonAPI>`: import `visiontoolkit` and make use of any
+applicable objects such as functions and exceptions.
+
+A good place to start might be the `colocate` function, which accepts a
+model field and an observational field and colocates the former onto
+the latter.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 cf-python>=3.17.0
-cf-plot>=3.4.0
 esmpy>=8.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cf-python>=3.17.0
 cf-plot>=3.4.0
+esmpy>=8.7.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ extras_require = {
         "sphinx",
         "shibuya",  # chosen and configured docs theme
     ],
-    "pre-commit hooks": [
+    "pre_commit_hooks": [
         "pre-commit",
         "black",
         "flake8",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,12 @@ long_description = (
 
 tests_require = ()
 extras_require = {
-    # "documentation": [],  # TODO add when add docs
+    "plotting": [
+        "cf-plot>=3.4.0",
+    ]
+    "documentation": [
+        "sphinx",
+    ],
     "pre-commit hooks": [
         "pre-commit",
         "black",

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,10 @@ tests_require = ()
 extras_require = {
     "plotting": [
         "cf-plot>=3.4.0",
-    ]
+    ],
     "documentation": [
         "sphinx",
+        "shibuya",  # chosen and configured docs theme
     ],
     "pre-commit hooks": [
         "pre-commit",

--- a/visiontoolkit/cli.py
+++ b/visiontoolkit/cli.py
@@ -151,14 +151,6 @@ def process_cli_arguments(parser):
         ),
     )
     parser.add_argument(
-        "--skip-all-plotting",
-        action="store_true",
-        help=(
-            "Do not generate plots to preview the input or show the output "
-            "fields"
-        ),
-    )
-    parser.add_argument(
         "-d",
         "--outputs-dir",
         action="store",
@@ -225,22 +217,19 @@ def process_cli_arguments(parser):
         help="initial text to use in the names of all plots generated",
     )
     parser.add_argument(
-        "--show-plot-of-input-obs",
-        action="store_true",
+        "--plot-mode",
+        action="store",
         help=(
-            "flag to indicate whether to show plots of the input "
-            "observational data before the colocation logic begins, as "
-            "a preview"
-        ),
-    )
-    parser.add_argument(
-        "-t",
-        "--plot-of-input-obs-track-only",
-        action="store_true",
-        help=(
-            "flag to indicate whether only the track/trajectory "
-            "of the observational data is shown, as opposed to the data "
-            "on the track, for the input observational data preview plots"
+            "what to plot with cf-plot, where integer inputs represent the "
+            "supported modes, which are: 0 to not plot anything, 1 to plot "
+            "both the outputs and, before starting colocation, as a "
+            "means of verification and/or quick inpection, the observational "
+            "input (with its data), 2 to plot only the outputs (the default "
+            "mode, if plot-mode is not specified) and 3 to plot both the "
+            "outputs and observational input but only show the track/swath "
+            "of the inputs without the data on it to indicate the track/swath "
+            "which the model field will then be colocated onto (the most "
+            "relevant part of the observational input for VISION purposes)"
         ),
     )
     parser.add_argument(
@@ -349,9 +338,9 @@ def process_cli_arguments(parser):
         action="store",
         help=(
             "NOW DEPRECATED: use '--spatial-colocation-method' instead. "
-            "regridding interpolation method to apply, see 'method' "
+            "[regridding interpolation method to apply, see 'method' "
             "parameter to 'cf.regrids' method for options: "
-            "https://ncas-cms.github.io/cf-python/method/cf.Field.regrids.html"
+            "https://ncas-cms.github.io/cf-python/method/cf.Field.regrids.html]"
         ),
     )
     parser.add_argument(
@@ -372,6 +361,37 @@ def process_cli_arguments(parser):
             "Note that we no longer accept an integer corresponding to a "
             "FieldList index to take a field from like this keyword "
             "permitted, now we require a valid 'select_field' string argument."
+        ),
+    )
+    # All three below replaced by plot-mode:
+    parser.add_argument(
+        "-t",
+        "--plot-of-input-obs-track-only",
+        action="store_true",
+        help=(
+            "NOW DEPRECATED: use '--plot-mode' instead. "
+            "[flag to indicate whether only the track/trajectory "
+            "of the observational data is shown, as opposed to the data "
+            "on the track, for the input observational data preview plots]"
+        ),
+    )
+    parser.add_argument(
+        "--skip-all-plotting",
+        action="store_true",
+        help=(
+            "NOW DEPRECATED: use '--plot-mode' instead. "
+            "[Do not generate plots to preview the input or show the output "
+            "fields]"
+        ),
+    )
+    parser.add_argument(
+        "--show-plot-of-input-obs",
+        action="store_true",
+        help=(
+            "NOW DEPRECATED: use '--plot-mode' instead. "
+            "[flag to indicate whether to show plots of the input "
+            "observational data before the colocation logic begins, as "
+            "a preview]"
         ),
     )
 

--- a/visiontoolkit/configurations/um-faam-stanco-1.json
+++ b/visiontoolkit/configurations/um-faam-stanco-1.json
@@ -5,7 +5,7 @@
     "chosen-model-field":"id%UM_m01s51i010_vn1105",
     "outputs-dir":"toolkit-outputs/um-faam-stanco-1",
     "output-file-name":"um_faam_stanco_1_vision_result.nc",
-    "plot-of-input-obs-track-only":2,
+    "plot-mode":3,
     "cfp-cscale": "WhiteBlueGreenYellowRed",
     "cfp-mapset-config":{
         "lonmin":-2,

--- a/visiontoolkit/configurations/um-faam-stanco-2.json
+++ b/visiontoolkit/configurations/um-faam-stanco-2.json
@@ -6,8 +6,7 @@
     "chosen-model-field":"id%UM_m01s51i010_vn1105",
     "outputs-dir":"toolkit-outputs/um-faam-stanco-2",
     "output-file-name":"um_faam_stanco_2_vision_result.nc",
-    "show-plot-of-input-obs": false,
-    "plot-of-input-obs-track-only": 0,
+    "plot-mode":2,
     "cfp-cscale": "WhiteBlueGreenYellowRed",
     "cfp-mapset-config":{
         "lonmin":-2,

--- a/visiontoolkit/configurations/um-faam-stanco-3.json
+++ b/visiontoolkit/configurations/um-faam-stanco-3.json
@@ -6,8 +6,7 @@
     "chosen-model-field":"id%UM_m01s51i010_vn1105",
     "outputs-dir":"toolkit-outputs/um-faam-stanco-3",
     "output-file-name":"um_faam_stanco_3_vision_result.nc",
-    "show-plot-of-input-obs": false,
-    "plot-of-input-obs-track-only": 0,
+    "plot-mode":2,
     "cfp-cscale": "WhiteBlueGreenYellowRed",
     "cfp-mapset-config":{
         "lonmin":-2,

--- a/visiontoolkit/configurations/um-faam-stanco-4-istwopointof1.json
+++ b/visiontoolkit/configurations/um-faam-stanco-4-istwopointof1.json
@@ -5,7 +5,7 @@
     "chosen-model-field":"id%UM_m01s51i010_vn1105",
     "outputs-dir":"toolkit-outputs/um-faam-stanco-4",
     "output-file-name":"um_faam_stanco_4_vision_result.nc",
-    "plot-of-input-obs-track-only":2,
+    "plot-mode":3,
     "cfp-cscale": "WhiteBlueGreenYellowRed",
     "cfp-mapset-config":{
         "lonmin":-2,

--- a/visiontoolkit/configurations/um-faam-stanco-5-isanothertwopointof1.json
+++ b/visiontoolkit/configurations/um-faam-stanco-5-isanothertwopointof1.json
@@ -6,7 +6,7 @@
     "outputs-dir":"toolkit-outputs/um-faam-stanco-5",
     "output-file-name":"um_faam_stanco_5_vision_result.nc",
     "halo-size": 0, 
-    "plot-of-input-obs-track-only":2,
+    "plot-mode":3,
     "cfp-cscale": "WhiteBlueGreenYellowRed",
     "cfp-mapset-config":{
         "lonmin":-2,

--- a/visiontoolkit/configurations/um-hybrid-height-faam-stanco-1.json
+++ b/visiontoolkit/configurations/um-hybrid-height-faam-stanco-1.json
@@ -7,5 +7,5 @@
     "chosen-model-field":"air_temperature",
     "outputs-dir":"toolkit-outputs/um-hybrid-height-faam-stanco-1",
     "output-file-name":"um_hh_faam_stanco_1_vision_result.nc",
-    "skip-all-plotting":true
+    "plot-mode":0
 }

--- a/visiontoolkit/configurations/um-hybrid-height-faam-stanco-2.json
+++ b/visiontoolkit/configurations/um-hybrid-height-faam-stanco-2.json
@@ -7,5 +7,5 @@
     "chosen-model-field":"id%UM_m01s34i104_vn1105",
     "outputs-dir":"toolkit-outputs/um-hybrid-height-faam-stanco-2",
     "output-file-name":"um_hh_faam_stanco_2_vision_result.nc",
-    "skip-all-plotting":true
+    "plot-mode":0
 }

--- a/visiontoolkit/configurations/um-hybrid-height-faam-stanco-3.json
+++ b/visiontoolkit/configurations/um-hybrid-height-faam-stanco-3.json
@@ -7,5 +7,5 @@
     "chosen-model-field":"id%UM_m01s34i117_vn1105",
     "outputs-dir":"toolkit-outputs/um-hybrid-height-faam-stanco-3",
     "output-file-name":"um_hh_faam_stanco_3_vision_result.nc",
-    "skip-all-plotting":true
+    "plot-mode":0
 }

--- a/visiontoolkit/configurations/um-satellite-1.json
+++ b/visiontoolkit/configurations/um-satellite-1.json
@@ -1,6 +1,6 @@
 {
     "start-time-override": "2017-07-17 03:14:15",
-    "show-plot-of-input-obs": false,
+    "plot-mode":2,
     "obs-data-path":"../data/marias-satellite-example-data/satellite-data/ral-l2p-tqoe-iasi_mhs_amsu_metopa-tir_mw-20170703201158z_20170703215054z_350_399-v1000.nc",
     "model-data-path":"../data/main-workwith-test-ISO-simulator/Model_Input",
     "preprocess-mode-obs":"satellite",
@@ -8,7 +8,6 @@
     "chosen-model-field":"id%UM_m01s51i010_vn1105",
     "outputs-dir":"toolkit-outputs/um-satellite-1",
     "output-file-name":"um_satellite_1_vision_result.nc",
-    "skip-all-plotting":false,
     "cfp-mapset-config":{
         "resolution":"10m",
         "proj":"spstere",

--- a/visiontoolkit/configurations/um-satellite-10speedtest.json
+++ b/visiontoolkit/configurations/um-satellite-10speedtest.json
@@ -7,5 +7,4 @@
     "chosen-model-field":"id%UM_m01s51i010_vn1105",
     "outputs-dir":"toolkit-outputs/um-satellite-10",
     "output-file-name":"um_satellite_10_vision_result.nc",
-    "skip-all-plotting":true
 }

--- a/visiontoolkit/configurations/um-satellite-2.json
+++ b/visiontoolkit/configurations/um-satellite-2.json
@@ -7,7 +7,7 @@
     "chosen-model-field":"id%UM_m01s51i010_vn1105",
     "outputs-dir":"toolkit-outputs/um-satellite-2",
     "output-file-name":"um_satellite_2_vision_result.nc",
-    "skip-all-plotting":false,
+    "plot-mode":3,
     "cfp-mapset-config":{
         "resolution":"10m"
     },

--- a/visiontoolkit/configurations/um-satellite-3.json
+++ b/visiontoolkit/configurations/um-satellite-3.json
@@ -8,7 +8,7 @@
     "chosen-model-field":"id%UM_m01s51i010_vn1105",
     "outputs-dir":"toolkit-outputs/um-satellite-3",
     "output-file-name":"um_satellite_3_vision_result.nc",
-    "skip-all-plotting":false,
+    "plot-mode":3,
     "cfp-mapset-config":{
         "resolution":"10m",
         "proj":"spstere",

--- a/visiontoolkit/configurations/um-satellite-4.json
+++ b/visiontoolkit/configurations/um-satellite-4.json
@@ -7,7 +7,7 @@
     "chosen-model-field":"id%UM_m01s51i010_vn1105",
     "outputs-dir":"toolkit-outputs/um-satellite-4",
     "output-file-name":"um_satellite_4_vision_result.nc",
-    "skip-all-plotting":false,
+    "plot-mode":3,
     "cfp-mapset-config":{
         "resolution":"10m",
         "proj":"robin"

--- a/visiontoolkit/configurations/um-satellite-5.json
+++ b/visiontoolkit/configurations/um-satellite-5.json
@@ -7,7 +7,7 @@
     "chosen-model-field":"id%UM_m01s51i010_vn1105",
     "outputs-dir":"toolkit-outputs/um-satellite-5",
     "output-file-name":"um_satellite_5_vision_result.nc",
-    "skip-all-plotting":false,
+    "plot-mode":3,
     "cfp-mapset-config":{
         "resolution":"10m",
         "proj":"robin"

--- a/visiontoolkit/configurations/um-satellite-6.json
+++ b/visiontoolkit/configurations/um-satellite-6.json
@@ -7,7 +7,7 @@
     "chosen-model-field":"id%UM_m01s51i010_vn1105",
     "outputs-dir":"toolkit-outputs/um-satellite-6",
     "output-file-name":"um_satellite_6_vision_result.nc",
-    "skip-all-plotting":false,
+    "plot-mode":3,
     "cfp-mapset-config":{
         "resolution":"10m",
         "lonmin":125,

--- a/visiontoolkit/configurations/um-satellite-7.json
+++ b/visiontoolkit/configurations/um-satellite-7.json
@@ -7,7 +7,7 @@
     "chosen-model-field":"id%UM_m01s51i010_vn1105",
     "outputs-dir":"toolkit-outputs/um-satellite-7",
     "output-file-name":"um_satellite_7_vision_result.nc",
-    "skip-all-plotting":false,
+    "plot-mode":3,
     "cfp-mapset-config":{
         "resolution":"10m",
         "proj": "spstere",

--- a/visiontoolkit/configurations/um-satellite-8.json
+++ b/visiontoolkit/configurations/um-satellite-8.json
@@ -7,7 +7,7 @@
     "chosen-model-field":"id%UM_m01s51i010_vn1105",
     "outputs-dir":"toolkit-outputs/um-satellite-8",
     "output-file-name":"um_satellite_8_vision_result.nc",
-    "skip-all-plotting":false,
+    "plot-mode":3,
     "cfp-mapset-config":{
         "resolution":"10m"
     },

--- a/visiontoolkit/configurations/um-satellite-9.json
+++ b/visiontoolkit/configurations/um-satellite-9.json
@@ -7,8 +7,7 @@
     "chosen-model-field":"id%UM_m01s51i010_vn1105",
     "outputs-dir":"toolkit-outputs/um-satellite-9",
     "output-file-name":"um_satellite_9_vision_result.nc",
-    "skip-all-plotting":false,
-    "show-plot-of-input-obs": false,
+    "plot-mode":2,
     "cfp-mapset-config":{
         "resolution":"10m",
         "proj":"robin"

--- a/visiontoolkit/configurations/wrf-faam-stanco-1.json
+++ b/visiontoolkit/configurations/wrf-faam-stanco-1.json
@@ -9,8 +9,7 @@
     "output-file-name": "wrf_faam_stanco_1_vision_result.nc",
     "vertical-colocation-coord": "atmosphere_hybrid_sigma_pressure_coordinate",
     "source-axes": {"X": "ncdim%west_east", "Y": "ncdim%south_north"},
-    "plot-of-input-obs-track-only": 2,
-    "skip-all-plotting":true,
+    "plot-mode":0,
     "cfp-mapset-config": {
         "lonmin": -2,
         "lonmax": 2,

--- a/visiontoolkit/configurations/wrf-faam-stanco-2.json
+++ b/visiontoolkit/configurations/wrf-faam-stanco-2.json
@@ -9,8 +9,7 @@
     "output-file-name": "wrf_faam_stanco_2_vision_result.nc",
     "vertical-colocation-coord": "atmosphere_hybrid_sigma_pressure_coordinate",
     "source-axes": {"X": "ncdim%west_east", "Y": "ncdim%south_north"},
-    "show-plot-of-input-obs": false,
-    "plot-of-input-obs-track-only": 0,
+    "plot-mode":2,
     "cfp-mapset-config": {
         "lonmin": -2,
         "lonmax": 2,

--- a/visiontoolkit/configurations/wrf-faam-stanco-3.json
+++ b/visiontoolkit/configurations/wrf-faam-stanco-3.json
@@ -9,7 +9,7 @@
     "output-file-name": "wrf_faam_stanco_3_vision_result.nc",
     "vertical-colocation-coord": "atmosphere_hybrid_sigma_pressure_coordinate",
     "source-axes": {"X": "ncdim%west_east", "Y": "ncdim%south_north"},
-    "show-plot-of-input-obs": false,
+    "plot-mode":2,
     "cfp-mapset-config": {
         "lonmin": -2,
         "lonmax": 2,

--- a/visiontoolkit/configurations/wrf-faam-stanco-4.json
+++ b/visiontoolkit/configurations/wrf-faam-stanco-4.json
@@ -8,7 +8,7 @@
     "output-file-name": "wrf_faam_stanco_4_vision_result.nc",
     "vertical-colocation-coord": "atmosphere_hybrid_sigma_pressure_coordinate",
     "source-axes": {"X": "ncdim%west_east", "Y": "ncdim%south_north"},
-    "show-plot-of-input-obs": false,
+    "plot-mode":2,
     "cfp-mapset-config": {
         "lonmin": -2,
         "lonmax": 2,

--- a/visiontoolkit/configurations/wrf-faam-stanco-5-minimaltwopointcase.json
+++ b/visiontoolkit/configurations/wrf-faam-stanco-5-minimaltwopointcase.json
@@ -8,8 +8,7 @@
     "output-file-name": "wrf_faam_stanco_5_vision_result.nc",
     "vertical-colocation-coord": "atmosphere_hybrid_sigma_pressure_coordinate",
     "source-axes": {"X": "ncdim%west_east", "Y": "ncdim%south_north"},
-    "plot-of-input-obs-track-only": false,
-    "skip-all-plotting":true,
+    "plot-mode":0,
     "cfp-mapset-config": {
         "lonmin": -2,
         "lonmax": 2,

--- a/visiontoolkit/constants.py
+++ b/visiontoolkit/constants.py
@@ -7,7 +7,6 @@ CONFIG_DEFAULTS = {
     # TODO: Get ESMF logging via cf incoporated into Python logging system,
     # see Issue #286.
     "verbose": 0,  # corresponds to a count of 0 (-v would be 1, -vv 2, etc.)
-    "skip-all-plotting": False,
     # *** Run mode with time override(s) ***
     # Specify the mode on which to run the E2E, where valid choices are:
     # 1. a mode to take data as-is assuming the model input data spans the
@@ -59,22 +58,14 @@ CONFIG_DEFAULTS = {
     "vertical-colocation-coord": "air_pressure",
     "source-axes": False,
     # *** Plotting: what to plot and how to minimally configure it ***
+    "plot-mode": 2,
     "plotname-start": "vision_toolkit",
-    # Optionally, display plots of the input observational data, or its track
-    # only in one colour (if 'plot-of-input-obs-track-only' is set to True).
-    # This could be useful for previewing the track to be colocated
-    # onto, to fail early if the user isn't happy with the track,
-    # or for demo'ing the code to compare the original observational data
-    # to the co-located data to see the differences.
-    "show-plot-of-input-obs": True,
-    # Bool but for dev. purposes, if set to 2 then it shows both plots:
-    "plot-of-input-obs-track-only": True,
     # "parula" also works well, as alternative for dev. work:
     "cfp-cscale": "plasma",
     "cfp-mapset-config": {},
     "cfp-input-levs-config": {},
     "cfp-input-track-only-config": {
-        "legend": True,  # TODO sepaarte into setvars config and plot opts
+        "legend": True,  # TODO separate into setvars config and plot opts
         "colorbar": False,
         "markersize": 0.5,
         "linewidth": 0.0,  # turn off line plotting to only have markers
@@ -99,6 +90,18 @@ CONFIG_DEFAULTS = {
         "linewidth": 0.0,
         "title": "Result: model co-located onto observational path",
     },
+    # Note, deprecations:
+    # Bool but for dev. purposes, if set to 2 then it shows both plots:
+    #"plot-of-input-obs-track-only": True,
+    #
+    # Optionally, display plots of the input observational data, or its track
+    # only in one colour (if 'plot-of-input-obs-track-only' is set to True).
+    # This could be useful for previewing the track to be colocated
+    # onto, to fail early if the user isn't happy with the track,
+    # or for demo'ing the code to compare the original observational data
+    # to the co-located data to see the differences.
+    #"show-plot-of-input-obs": True,
+    # "skip-all-plotting": False,
 }
 
 

--- a/visiontoolkit/constants.py
+++ b/visiontoolkit/constants.py
@@ -58,7 +58,7 @@ CONFIG_DEFAULTS = {
     "vertical-colocation-coord": "air_pressure",
     "source-axes": False,
     # *** Plotting: what to plot and how to minimally configure it ***
-    "plot-mode": 2,
+    "plot-mode": 0,  # NEW DEFAULT, SLB ENSURE BACK COMPAT.
     "plotname-start": "vision_toolkit",
     # "parula" also works well, as alternative for dev. work:
     "cfp-cscale": "plasma",
@@ -101,7 +101,7 @@ CONFIG_DEFAULTS = {
     # or for demo'ing the code to compare the original observational data
     # to the co-located data to see the differences.
     #"show-plot-of-input-obs": True,
-    # "skip-all-plotting": False,
+    #"skip-all-plotting": False,
 }
 
 

--- a/visiontoolkit/plotting.py
+++ b/visiontoolkit/plotting.py
@@ -14,8 +14,7 @@ logger = logging.getLogger(__name__)
 
 def preview_plots(
     obs_field,
-    show_plot_of_input_obs,
-    plot_of_input_obs_track_only,
+    plot_mode,
     outputs_dir,
     plotname_start,
     cfp_mapset_config,
@@ -42,48 +41,60 @@ def preview_plots(
     else:
         index = f"_{index}"
 
-    if show_plot_of_input_obs:
-        # Plot *input* observational data for a preview, before doing anything
-        # Min, max as determined using final_result_field.min(), .max():
-        if cfp_input_levs_config:
-            cfp.levs(**cfp_input_levs_config)
-        if plot_of_input_obs_track_only in (1, 2):
-            # Use the same field but set all data to zero so can plot the whole
-            # track in the same colour to just display the path, not orig. data
-            equal_data_obs_field = obs_field.copy()
-            new_data = np.zeros(
-                len(equal_data_obs_field.data)
-            )  # 0 -> force red with colour scheme set later
-            equal_data_obs_field.set_data(new_data, inplace=True)
+    # Determine plotting mode, default is 2 (plot only outputs):
+    #   0 i.e. False. Don't plot anything (skip all)
+    #   1 i.e. standard True: plot both inputs (data on tracks) and outputs
+    #   2 meaning true in that we plot, but we only plot the outputs
+    #   3 meaning true in that we plot both inputs and outputs, but inputs
+    #     are shown track-only i.e. with no data shown on them
+    #
+    # Could do e.g. 4 and 5 for inputs only (data on track or just track),
+    # but doubt there's motivation/application for that unless asked and
+    # if we have 5+ modes it is better to change to use two plus flags
 
-            # Not configurable, always use since it gives red for zero values
-            # therefore whole track will be red to make it clear it is a block
-            # colour without meaning attached
-            cfp.cscale("scale28")
-            cfp.gopen(
-                file=(
-                    f"{outputs_dir}/"
-                    f"{plotname_start}_obs_track_only{index}.png"
-                )
+    if cfp_input_levs_config:
+        cfp.levs(**cfp_input_levs_config)
+
+    # Plot *input* observational data for a preview, before doing anything
+    # Min, max as determined using final_result_field.min(), .max():
+    if plot_mode == 1:  # i.e. plot inputs with data on tracks
+        ### plot_of_input_obs_track_only in (0, 2):
+        cfp.gopen(
+            file=(
+                f"{outputs_dir}/"
+                f"{plotname_start}_obs_track_with_data_{index}.png"
             )
-            cfp_input_track_only_config.update(verbose=verbose)
-            cfp.traj(
-                equal_data_obs_field, **cfp_input_track_only_config
+        )
+        cfp_input_general_config.update(verbose=verbose)
+        cfp.traj(obs_field, **cfp_input_general_config)
+        cfp.gclose()
+    elif plot_mode == 3:  # i.e. plot inputs as tracks only, without data on
+        # Use the same field but set all data to zero so can plot the whole
+        # track in the same colour to just display the path, not orig. data
+        equal_data_obs_field = obs_field.copy()
+        new_data = np.zeros(
+            len(equal_data_obs_field.data)
+        )  # 0 -> force red with colour scheme set later
+        equal_data_obs_field.set_data(new_data, inplace=True)
+
+        # Not configurable, always use since it gives red for zero values
+        # therefore whole track will be red to make it clear it is a block
+        # colour without meaning attached
+        cfp.cscale("scale28")
+        cfp.gopen(
+            file=(
+                f"{outputs_dir}/"
+                f"{plotname_start}_obs_track_only{index}.png"
             )
-            cfp.gclose()
-            cfp.cscale(
-                cfp_cscale
-            )  # reset for normal (default-style) plots after
-        if plot_of_input_obs_track_only in (0, 2):
-            cfp.gopen(
-                file=(
-                    f"{outputs_dir}/"
-                    f"{plotname_start}_obs_track_with_data_{index}.png"
-                )
-            )
-            cfp_input_general_config.update(verbose=verbose)
-            cfp.traj(obs_field, **cfp_input_general_config)
-            cfp.gclose()
+        )
+        cfp_input_track_only_config.update(verbose=verbose)
+        cfp.traj(
+            equal_data_obs_field, **cfp_input_track_only_config
+        )
+        cfp.gclose()
+        cfp.cscale(
+            cfp_cscale
+        )  # reset for normal (default-style) plots after
 
 
 def output_plots(

--- a/visiontoolkit/plotting.py
+++ b/visiontoolkit/plotting.py
@@ -3,7 +3,12 @@
 import logging
 
 # NOTE: keep this order (cfp then cf imported) to avoid Seg Fault issues
-import cfplot as cfp
+cfplot_imported = False
+try:
+    import cfplot as cfp  # noqa: F401
+    cfplot_imported = True
+except ImportError:
+    pass
 import cf
 
 import numpy as np
@@ -32,6 +37,11 @@ def preview_plots(
 
     TODO: DETAILED DOCS
     """
+    if not cfplot_imported:
+        raise ValueError(
+            "Unable to plot: must have suitable version of cf-plot installed "
+            "for VISION toolkit plotting functionality."
+        )
     # First configure general settings for plot
     # Change the viewpoint to be over the UK only, with high-res map outline
     cfp.mapset(**cfp_mapset_config)
@@ -113,6 +123,12 @@ def output_plots(
 
     TODO: DETAILED DOCS
     """
+    if not cfplot_imported:
+        raise ValueError(
+            "Unable to plot: must have suitable version of cf-plot installed "
+            "for VISION toolkit plotting functionality."
+        )
+
     cfp_output_general_config.update(verbose=verbose)
 
     # Make and open the final plot

--- a/visiontoolkit/tests/test_general.py
+++ b/visiontoolkit/tests/test_general.py
@@ -109,7 +109,7 @@ class TestFlightObservationsUMModelConstantPressure:
             "min": 5e-08,
             "step": 2.5e-09,
         },
-        "plot-of-input-obs-track-only": 2,
+        "plot-mode": 2,
     }
 
     def test_config_c1_flight_um(self, capsys, tmp_path):
@@ -118,7 +118,7 @@ class TestFlightObservationsUMModelConstantPressure:
             **self.base_config_constant_vert_levs,
             **{
                 # Changes relative to base configuration choice, if any
-                "plot-of-input-obs-track-only": 2,
+                "plot-mode": 3,
                 # Not relevant to testing: names outputs
                 "output-file-name": "um_faam_stanco_1_vision_result.nc",
                 "outputs-dir": "toolkit-outputs/um-faam-stanco-1",
@@ -168,7 +168,7 @@ class TestFlightObservationsUMModelConstantPressure:
                 # Changes relative to base configuration choice, if any
                 "obs-data-path": f"{self.obs_data_root}core_faam_20170703_c016_STANCO_CF-two-point-1.nc",
                 "chosen-obs-field": "mole_fraction_of_ozone_in_air",
-                "plot-of-input-obs-track-only": 2,
+                "plot-mode": 3,
                 # Not relevant to testing: names outputs
                 "output-file-name": "um_faam_stanco_4_vision_result.nc",
                 "outputs-dir": "toolkit-outputs/um-faam-stanco-4",
@@ -186,6 +186,7 @@ class TestFlightObservationsUMModelConstantPressure:
                 "chosen-obs-field": "mole_fraction_of_ozone_in_air",
                 "halo-size": 0,
                 "plot-of-input-obs-track-only": 2,
+                "plot-mode": 3,
                 # Not relevant to testing: names outputs
                 "output-file-name": "um_faam_stanco_5_vision_result.nc",
                 "outputs-dir": "toolkit-outputs/um-faam-stanco-5",
@@ -236,7 +237,7 @@ class TestFlightObservationsUMModelHybridHeight:
         #     "min": 4.5e-08,
         #     "step": 0.5e-08,
         # },
-        "skip-all-plotting": True,
+        "plot-mode": 0,
         # Other
         "start-time-override": "1998-02-21 11:50:00",
     }
@@ -306,6 +307,7 @@ class TestFlightObservationsWRFModel:
         "chosen-model-field": "ncvar%T",
         "source-axes": {"X": "ncdim%west_east", "Y": "ncdim%south_north"},
         "vertical-colocation-coord": "atmosphere_hybrid_sigma_pressure_coordinate",
+        "plot-mode": 2,
         "cfp-mapset-config": {
             "latmax": 54,
             "latmin": 50,
@@ -324,8 +326,7 @@ class TestFlightObservationsWRFModel:
             **{
                 # Changes relative to base configuration choice, if any
                 "start-time-override": "2023-07-10 12:00:00",
-                "plot-of-input-obs-track-only": 2,
-                "skip-all-plotting": True,
+                "plot-mode": 0,
                 # Not relevant to testing: names outputs
                 "output-file-name": "wrf_faam_stanco_1_vision_result.nc",
                 "outputs-dir": "toolkit-outputs/wrf-faam-stanco-1",
@@ -340,8 +341,6 @@ class TestFlightObservationsWRFModel:
             **{
                 # Changes relative to base configuration choice, if any
                 "start-time-override": "2023-07-11 18:00:00",
-                "plot-of-input-obs-track-only": 0,
-                "show-plot-of-input-obs": False,
                 # Not relevant to testing: names outputs
                 "output-file-name": "wrf_faam_stanco_2_vision_result.nc",
                 "outputs-dir": "toolkit-outputs/wrf-faam-stanco-2",
@@ -356,7 +355,6 @@ class TestFlightObservationsWRFModel:
             **{
                 # Changes relative to base configuration choice, if any
                 "start-time-override": "2023-07-11 03:14:15",
-                "show-plot-of-input-obs": False,
                 # Not relevant to testing: names outputs
                 "output-file-name": "wrf_faam_stanco_3_vision_result.nc",
                 "outputs-dir": "toolkit-outputs/wrf-faam-stanco-3",
@@ -371,7 +369,6 @@ class TestFlightObservationsWRFModel:
             **{
                 # Changes relative to base configuration choice, if any
                 "start-time-override": "2023-07-12 03:14:15",
-                "show-plot-of-input-obs": False,
                 # Not relevant to testing: names outputs
                 "output-file-name": "wrf_faam_stanco_4_vision_result.nc",
                 "outputs-dir": "toolkit-outputs/wrf-faam-stanco-4",
@@ -395,8 +392,7 @@ class TestFlightObservationsWRFModel:
                 "obs-data-path": "../data/2025-laurents-twopoint-flight/field.nc",
                 "chosen-obs-field": "ncvar%tc",
                 "start-time-override": "2023-07-10 12:00:00",
-                "plot-of-input-obs-track-only": False,
-                "skip-all-plotting": True,
+                "plot-mode": 0,
                 # Not relevant to testing: names outputs
                 "output-file-name": "wrf_faam_stanco_5_vision_result.nc",
                 "outputs-dir": "toolkit-outputs/wrf-faam-stanco-5",
@@ -421,7 +417,7 @@ class TestSatelliteObservationsUMModel:
         "model-data-path": "../data/main-workwith-test-ISO-simulator/Model_Input",
         "preprocess-mode-obs": "satellite",
         "chosen-model-field": "id%UM_m01s51i010_vn1105",
-        "skip-all-plotting": False,
+        "plot-mode": 3,
     }
 
     def test_config_c1_satellite_um(self, capsys, tmp_path):
@@ -435,7 +431,7 @@ class TestSatelliteObservationsUMModel:
                 "obs-data-path": f"{self.obs_data_root}-20170703201158z_20170703215054z_350_399-v1000.nc",
                 "start-time-override": "2017-07-17 03:14:15",
                 "cfp-cscale": "inferno",
-                "show-plot-of-input-obs": False,
+                "plot-mode": 2,
                 "cfp-input-levs-config": {"max": 55, "min": -5, "step": 5},
                 "cfp-mapset-config": {
                     "boundinglat": -60,
@@ -657,7 +653,7 @@ class TestSatelliteObservationsUMModel:
                 ),
                 "obs-data-path": f"{self.obs_data_root}-201707032*",
                 "start-time-override": "2017-07-21 00:00:00",
-                "show-plot-of-input-obs": False,
+                "plot-mode": 2,
                 "cfp-cscale": "plasma",
                 "cfp-input-levs-config": {"max": 55, "min": -5, "step": 5},
                 "cfp-mapset-config": {"proj": "robin", "resolution": "10m"},
@@ -675,6 +671,7 @@ class TestSatelliteObservationsUMModel:
 
     def test_config_c10_satellite_um(self, capsys, tmp_path):
         """TODO c10: TODO describe main reasons for config."""
+        # Note tests default plot mode as no / skip all plotting
         c10_satellite_um = {
             **self.base_config_satellite_um,
             **{
@@ -685,7 +682,6 @@ class TestSatelliteObservationsUMModel:
                 ),
                 "obs-data-path": f"{self.obs_data_dir}/*",
                 "start-time-override": "2017-07-21 00:00:00",
-                "skip-all-plotting": True,
                 # Not relevant to testing: names outputs
                 "output-file-name": "um_satellite_10_vision_result.nc",
                 "outputs-dir": "toolkit-outputs/um-satellite-10",

--- a/visiontoolkit/visiontoolkit.py
+++ b/visiontoolkit/visiontoolkit.py
@@ -8,10 +8,14 @@ from itertools import pairwise  # requires Python 3.10+
 from pprint import pformat
 from time import time
 
+
 # Import cfplot here even though not explicitly used to avoid
 # plotting module seg faults - cfplot needs overall to be imported first.
 # Will need to bypass 'isort' movement of this.
-import cfplot as cfp  # noqa: F401
+try:
+    import cfplot as cfp  # noqa: F401
+except ImportError:
+    pass
 import cf
 
 import numpy as np
@@ -30,11 +34,6 @@ from .plugins.wrf_data_compliance_fixes import (
     wrf_further_compliance_fixes,
 )
 
-
-SUPPORTED_PARAMETRIC_CONVERSIONS = (
-    "atmosphere_hybrid_height_coordinate",
-    "atmosphere_hybrid_sigma_pressure_coordinate",
-)
 
 # ----------------------------------------------------------------------------
 # Set up timing and logging
@@ -1729,13 +1728,15 @@ def colocate(
     vertical_key = "Z"
 
     # Handle parametric vertical coordinates:
-    # TODO, replace this check on coord refs with a check on the requested
+    # Currently supported parametric conversions are:
+    #   "atmosphere_hybrid_height_coordinate"
+    #   "atmosphere_hybrid_sigma_pressure_coordinate"
+
+    # TODO, check on coord refs with a check on the requested
     # "vertical-colocation-coord", if doesn't have one try computing from a
     # coord ref, if not fail with elegant message.
     coord_refs = model_field.coordinate_references(default=False)
     if coord_refs:
-        # Keep SUPPORTED_PARAMETRIC_CONVERSIONS list updated with cases use
-        # so can ensure support wat needed from CF Conventions Appendix D
         if model_field.coordinate_reference(
             "standard_name:atmosphere_hybrid_sigma_pressure_coordinate",
             default=False,
@@ -1843,7 +1844,7 @@ def main():
     history_message = args.history_message
     start_time_override = args.start_time_override
     # Plotting-only config
-    plot_mode = args.plot_mode  # NEW
+    plot_mode = args.plot_mode
     cfp_mapset_config = args.cfp_mapset_config
     cfp_cscale = args.cfp_cscale
     cfp_input_levs_config = args.cfp_input_levs_config

--- a/visiontoolkit/visiontoolkit.py
+++ b/visiontoolkit/visiontoolkit.py
@@ -1268,7 +1268,6 @@ def time_interpolation(
     spatially_colocated_field,
     history_message,
     is_satellite_case=False,
-    split_segments=False,
 ):
     """Interpolate the flight path temporally (in time T).
 
@@ -1281,8 +1280,6 @@ def time_interpolation(
     TODO: DETAILED DOCS
     """
     logger.info("Starting time interpolation step.")
-    if split_segments:
-        logger.info("Using split segments.\n")
 
     # Setup ready for iteration...
     m = spatially_colocated_field.copy()
@@ -1788,11 +1785,7 @@ def colocate(
     # For such cases as satellite swaths, the times can straddle model points
     # so we need to chop these up into ones on each side of a model time
     # segment as per our approach below.
-    is_satellite_case = False
-    split_segments = False
-    if preprocess_obs == "satellite":
-        is_satellite_case = True
-        split_segments = True
+    is_satellite_case = preprocess_obs == "satellite"
 
     final_result_field = time_interpolation(
         obs_times,
@@ -1805,7 +1798,6 @@ def colocate(
         spatially_colocated_field,
         history_message,
         is_satellite_case=is_satellite_case,
-        split_segments=split_segments,
     )
 
     return final_result_field, obs_t_identifier

--- a/visiontoolkit/visiontoolkit.py
+++ b/visiontoolkit/visiontoolkit.py
@@ -1585,7 +1585,6 @@ def write_output_data(final_result_field, output_path_name):
 @timeit
 def make_output_plots(
     output,
-    obs_t_identifier,
     cfp_output_levs_config,
     outputs_dir,
     plotname_start,

--- a/visiontoolkit/visiontoolkit.py
+++ b/visiontoolkit/visiontoolkit.py
@@ -1712,7 +1712,6 @@ def colocate(
             obs_times, obs_t_identifier, override_obs_start_time
         )
 
-    # TODO apply obs_t_identifier, model_t_identifier in further logic
     ensure_unit_calendar_consistency(obs_field, model_field)
 
     # Ensure the model time axes covers the entire time axes span of the
@@ -1722,9 +1721,7 @@ def colocate(
     # For the satellite swath cases, ignore vertical height since it is
     # dealt with by the averaging kernel.
     # TODO how do we account for the averging kernel work in this case?
-    no_vertical = False
-    if preprocess_obs == "satellite":
-        no_vertical = True
+    no_vertical = preprocess_obs == "satellite"
 
     # Where this is False, is taken as the key of the "Z" coordinate by default
     vertical_key = "Z"
@@ -1773,9 +1770,7 @@ def colocate(
         vertical_key=vertical_key,
     )
 
-    extra_compliance_proc_for_wrf = False
-    if preprocess_obs == "wrf":
-        extra_compliance_proc_for_wrf = True
+    extra_compliance_proc_for_wrf = preprocess_obs == "wrf"
 
     # Perform spatial and then temporal interpolation to colocate
     spatially_colocated_field = spatial_interpolation(


### PR DESCRIPTION
To address some feedback on issues found by Maria and some colleagues at Cambridge, namely:

* packaging improvements:
  * clarify installation process to be used until PyPI upload since there was confusion as to why the 'visiontoolkit' command wouldn't work without having run a local `pip` install;
  * add ESMPy as a dependency since we rely on regridding so it will always be needed, unlike for general cf-python usage;
* consolidate plotting functionality:
  * reduce the command line arguments for plotting from 3 flags to 1 `plot-mode`: the old flags were excessive for effectively only 3/4 mode options that could be toggled with one enumerated flag so have been deprecated;
  * perhaps most users will not want to do any plotting using the toolkit itself (they can do it afterwards in their own workflow) so set the default to mode `0` to skip all plotting;
  * make cf-plot an optional dependency now the default is to not plot anything;
* create a `colocate(model_field, obs_field)` function to house the core logic within `colocate_single_file` that operates on just one each of model and observational field input, to match the v1 toolkit (ISO simulator) API for plugin to existing workflows using that;
* flesh out some key docs pages, namely installation and quickstart, which are important to have up now ready for beta testing etc.